### PR TITLE
Get state, Set color, systemd file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+.#*
+/node_modules
+/config/default.json
+

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # node-tradfri-restapi
 
-What
----
+## What
+
 A simple REST-API implementation of [node-tradfri](https://www.npmjs.com/package/node-tradfri) with the following commands
 
  - `/tradfri/deviceids` will provide an array of device ids
@@ -9,31 +9,42 @@ A simple REST-API implementation of [node-tradfri](https://www.npmjs.com/package
  - `/tradfri/devices` will provide a full list of all devices including meta data
  - `/tradfri/groups` will provide a full list of all groups including devices and meta data
  - `/tradfri/device/:deviceid/:state` will set the state of a device (on/off). E.g. /tradfri/device/17101/on
- -  `/tradfri/group/:groupid/:state` will set the state of a device (on/off). E.g. /tradfri/device/11007/off
+ - `/tradfri/group/:groupid/:state` will set the state of a device (on/off). E.g. /tradfri/device/11007/off
 
 First release is a bit of a quick one. Exceptions needs to be managed and include toggle as an option. I did the API as I need to control my IKEA TRÅDFRI-lights with Node-RED but Node-RED does not support Node v7.x (I assume it will wait for the next LTS release) and a simple micro service is the short term solution to have it integrated and managed by Node-RED.
 
-How
----
-Setup libcoap as explained below
+## How
 
- 1. Setup libcoap as explained below
- 2. Rename `./config/default.json-sample` to `./config/default.json` and update with the IKEA hub information
- 3. Run using node >7.6 
+  1. Setup libcoap as explained below
+  2. `npm update` to install `node-tradfri` and other dependencies
+  3. Copy `./config/default.json-sample` as `./config/default.json` and update with the IKEA hub information
+  4. Run using Node >7.6, or simply use `nave`:
 
-Compiling libcoap
----
-Install libcoap as descibed below for Debian/Ubuntu/Raspbian:
+```sh
+nave use 7 node index.js
+```
+
+If you use `systemd` to manage your OS, eg. recent versions of Ubuntu Linux, then you can use the supplied `tradfri-restapi.service` file to perform start-up and job management.  Edit the `tradfri-restapi.service` file to match your install directory, user, group and so forth, and then:
+
+```sh
+systemctl link `pwd`/tradfri-restapi.service
+systemctl start tradfri-restapi
+journalctl -f tradfri-restapi
+```
+
+## Compiling libcoap
+
+Install libcoap as described below for Debian/Ubuntu/Raspbian:
 (credits to homebridge-tradfri)
 
+```sh
+apt-get install libtool git build-essential install autoconf automake
+git clone --recursive https://github.com/obgm/libcoap.git -b dtls
+cd libcoap
+git submodule update --init --recursive
+./autogen.sh
+./configure --disable-documentation --disable-shared
+make
 ```
-$ apt-get install libtool git build-essential install autoconf automake
-$ git clone --recursive https://github.com/obgm/libcoap.git
-$ cd libcoap
-$ git checkout dtls
-$ git submodule update --init --recursive
-$ ./autogen.sh
-$ ./configure --disable-documentation --disable-shared
-$ make```
 
-You'll find the coap-client binary in ./examples
+You'll find the coap-client binary in `./examples`.  This should be specified in the `config/default.json` file used above.

--- a/README.md
+++ b/README.md
@@ -8,6 +8,10 @@ A simple REST-API implementation of [node-tradfri](https://www.npmjs.com/package
  - `/tradfri/groupids` will provide an array of group ids
  - `/tradfri/devices` will provide a full list of all devices including meta data
  - `/tradfri/groups` will provide a full list of all groups including devices and meta data
+ - `/tradfri/device/:deviceid` will get the status of a device, including brightness and color
+ - `/tradfri/device/:deviceid/:state` will set the state of a device (on/off). E.g. /tradfri/device/17101/on
+ - `/tradfri/device/:deviceid/on?color=:color` will set the color of a device, in hex, or 'cool', 'warm', 'normal'
+ - `/tradfri/device/:deviceid/on?brightness=:brightness` will set the brightness of a device, from 0 to 255
  - `/tradfri/device/:deviceid/:state` will set the state of a device (on/off). E.g. /tradfri/device/17101/on
  - `/tradfri/group/:groupid/:state` will set the state of a device (on/off). E.g. /tradfri/device/11007/off
 

--- a/api/controller.js
+++ b/api/controller.js
@@ -74,6 +74,39 @@ exports.getGroups = function (req, res) {
     }
 }
 
+exports.getGroup = function (req, res) {
+    try {
+        tradfri.getGroups().then(groups => {
+            res.json({
+                item: (groups.filter(group => { return group.id == req.params.groupId })).shift(),
+                status: "ok"
+            });
+        });
+
+    } catch (err) {
+        res.json({
+            items: [],
+            status: "err"
+        });
+    }
+}
+
+exports.getDevice = function (req, res) {
+    try {
+        tradfri.getDevices().then(devices => {
+            res.json({
+                item: (devices.filter(device => { return device.id == req.params.deviceId })).shift(),
+                status: "ok"
+            });
+        });
+
+    } catch (err) {
+        res.json({
+            items: [],
+            status: "err"
+        });
+    }
+}
 
 exports.setDevice = function (req, res) {
     try {

--- a/api/controller.js
+++ b/api/controller.js
@@ -40,6 +40,7 @@ exports.getDevices = function (req, res) {
         });
     }
 }
+
 exports.getGroupIds = function (req, res) {
     try {
         tradfri.getGroupIds().then(groupIds => {
@@ -115,7 +116,19 @@ exports.setDevice = function (req, res) {
         };
 
         if (req.query.brightness && !isNaN(parseInt(req.query.brightness)) && req.query.brightness <= 255)
-            q.brightness = req.query.brightness;
+            q.brightness = parseInt(req.query.brightness);
+
+        if (req.query.color) {
+            q.color = req.query.color.toLowerCase();
+            switch (q.color) {
+            case 'focus':    case 'cool':   q.color = 'f5faf6'; break;
+            case 'everyday': case 'normal': q.color = 'f1e0b5'; break;
+            case 'relax':    case 'warm':   q.color = 'efd275'; break;
+            default:
+                if ( ! req.query.color.match('/^[0-9a-fA-F]{6}$/'))
+                    delete q.color;
+            }
+        }
 
         tradfri.setDeviceState(req.params.deviceId, q).then(
             res.json({

--- a/api/routes.js
+++ b/api/routes.js
@@ -1,19 +1,25 @@
 'use strict';
 
 module.exports = function(app) {
-	var controller = require('./controller.js');
+    var controller = require('./controller.js');
 
-	// todoList Routes
-	app.route('/tradfri/deviceids')
-		.get(controller.getDeviceIds);
-	app.route('/tradfri/devices')
-		.get(controller.getDevices);
-	app.route('/tradfri/groupids')
-		.get(controller.getGroupIds);
-	app.route('/tradfri/groups')
-		.get(controller.getGroups);
+    // todoList Routes
+    app.route('/tradfri/deviceids')
+       .get(controller.getDeviceIds);
+    app.route('/tradfri/devices')
+       .get(controller.getDevices);
+    app.route('/tradfri/groupids')
+       .get(controller.getGroupIds);
+    app.route('/tradfri/groups')
+       .get(controller.getGroups);
+
+    app.route('/tradfri/device/:deviceId')
+       .get(controller.getDevice);
     app.route('/tradfri/device/:deviceId/:state')
-        .get(controller.setDevice);
+       .get(controller.setDevice);
+
+    app.route('/tradfri/group/:groupId')
+       .get(controller.getGroup);
     app.route('/tradfri/group/:groupId/:state')
-        .get(controller.setGroup);
+       .get(controller.setGroup);
 };

--- a/index.js
+++ b/index.js
@@ -1,5 +1,7 @@
 'use strict';
 
+require("process").title = 'node-tradfri-restapi';
+
 var config = require("config");
 
 var express = require("express"),

--- a/tradfri-restapi.service
+++ b/tradfri-restapi.service
@@ -1,0 +1,23 @@
+[Unit]
+Description=RESTful API for TRADFRI lighting (temporary)
+Wants=network.target
+Documentation=https://github.com/nidayand/node-tradfri-restapi
+
+[Service]
+Type=simple
+User=node-red
+Group=node-red
+WorkingDirectory=/home/node-red/node-tradfri-restapi
+Nice=5
+Environment="NODE_OPTIONS=--max-old-space-size=128"
+ExecStart=/usr/bin/env nave use 7 node $NODE_OPTIONS $NODE_RED_OPTIONS index.js
+# Use SIGINT to stop
+KillSignal=SIGINT
+# Auto restart on crash
+Restart=on-failure
+# Tag things in the log
+SyslogIdentifier=tradfri-restapi
+#StandardOutput=syslog
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
Hi,

I've added a few things here; some might not be to your taste, such as the process title set (controversial?) and the `systemd` file.

The get calls for a device are particularly useful with the commit just pushed to `node-tradfri` (v 0.1.5) which includes the color and brightness values in the device data.

Feel free to pick and choose, or reject entirely!
